### PR TITLE
tree traversal like the Python implementation

### DIFF
--- a/src/main/java/rrcf/general/Tree.java
+++ b/src/main/java/rrcf/general/Tree.java
@@ -276,11 +276,11 @@ public class Tree implements Serializable {
         for (int i = 0; i < size(); i++) {
             double[][] bbox = node.point;
             Cut c = insertPointCut(point, bbox);
-            if (c.value < bbox[0][c.dim]) {
+            if (c.value <= bbox[0][c.dim]) {
                 leaf = new Leaf(point, i);
                 branch = new Branch(c, leaf, node, leaf.num + node.num);
                 break;
-            } else if (c.value >= bbox[bbox.length - 1][c.dim] && point[c.dim] > c.value) {
+            } else if (c.value >= bbox[bbox.length - 1][c.dim]) {
                 leaf = new Leaf(point, i);
                 branch = new Branch(c, node, leaf, leaf.num + node.num);
                 break;


### PR DESCRIPTION
I tried to replicate the first example in the paper, in the following way:
``` 
public static void main(String[] args) {
		//generates the data
		int n = 730;
		int A = 50;
		int center = 100;
		int phi = 30;
		double T = 2*Math.PI/100;
		double[] sin = new double[n];
		for (int i = 0; i < n; i++)
			sin[i] = i >= 235 && i < 255 ? 80 : A*Math.sin(T*i-phi*T) + center;	
			
		//creates forest of empty trees with suitable shingle
		int num_trees = 40;
		int shingle_size = 4;
		int tree_size = 256;
		ShingledForest forest = new ShingledForest(shingle_size,num_trees,tree_size);
		
		//calculates the codisp
		double[] avg_codisp = new double[n];
		for (int i = 0; i < n; i++) {
			avg_codisp[i] = forest.addPoint(sin[i]);
			System.out.println(i + " " + avg_codisp[i] + " " + sin[i]);
		}
}
```

Yet, the JavaRRCF stops at i = 103 with 
```
Exception in thread "main" java.lang.ClassCastException: class rrcf.Leaf cannot be cast to class rrcf.Branch (rrcf.Leaf and rrcf.Branch are in unnamed module of loader 'app')
	at rrcf.Tree.insertPoint(Tree.java:288)
	at rrcf.Forest.addPoint(Forest.java:55)
	at rrcf.ShingledForest.addPoint(ShingledForest.java:60)
```

Using 
```
c.value <= bbox[0][c.dim]
```
throws the same exception at i = 108.